### PR TITLE
Generate preimage with math library and use hex encoding + small fixes

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -372,13 +372,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.1"
-  random_string_generator:
-    dependency: "direct main"
-    description:
-      name: random_string_generator
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   sha3:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
 
 dependencies:
   dcli: ^1.7.1
-  random_string_generator: ^2.0.0
   znn_sdk_dart:
     git:
       url: https://github.com/sol-sanctum/znn_sdk_dart.git


### PR DESCRIPTION
Removed the `random_string_generator` dependency and used `dart:math` to create preimage.
Preimage is presented to user as a hex encoded string (the hashlock is also hex encoded).
Fixed some print messages.